### PR TITLE
Filter out workflow runs annotated with "skip" or "deleted" when checking if a workflow run has been processed before

### DIFF
--- a/pipedev-decider-utils/src/main/java/ca/on/oicr/pde/deciders/BasicDecider.java
+++ b/pipedev-decider-utils/src/main/java/ca/on/oicr/pde/deciders/BasicDecider.java
@@ -1081,7 +1081,7 @@ public class BasicDecider extends Plugin implements DeciderInterface {
         List<WorkflowRun> wrFiles1 = this.metadata.getWorkflowRunsAssociatedWithInputFiles(fileSWIDs, relevantWorkflows);
         LOGGER.debug("Found " + wrFiles1.size() + " workflow runs via direct search");
 
-        //filter workflowRuns that do not pass workflow run attribute tag filters
+        //select workflowRuns that do not have workflow run attribute tags
         List<WorkflowRun> filteredWorkflowRuns = wrFiles1.stream().filter(workflowRunAttributeFilter).collect(Collectors.toList());
         LOGGER.debug("After workflow run attribute filtering " + filteredWorkflowRuns.size() + " relevant workflow runs");
         return filteredWorkflowRuns;


### PR DESCRIPTION
- Add command line option to override to "workflow-run-annotation-tag-filters"