### PR TITLE
Upgrade Pinery

### DIFF
--- a/pipedev-decider-utils/pom.xml
+++ b/pipedev-decider-utils/pom.xml
@@ -23,6 +23,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <version>1.8</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>ca.on.oicr.gsi</groupId>
             <artifactId>pipedev-test-utils</artifactId>
             <scope>test</scope>

--- a/pipedev-decider-utils/src/main/java/ca/on/oicr/pde/deciders/BasicDecider.java
+++ b/pipedev-decider-utils/src/main/java/ca/on/oicr/pde/deciders/BasicDecider.java
@@ -71,13 +71,13 @@ import net.sourceforge.seqware.pipeline.tools.SetOperations;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.openide.util.lookup.ServiceProvider;
+import org.kohsuke.MetaInfServices;
 
 /**
  *
  * @author mtaschuk
  */
-@ServiceProvider(service = PluginInterface.class)
+@MetaInfServices(PluginInterface.class)
 public class BasicDecider extends Plugin implements DeciderInterface {
     private static final Logger LOGGER = LogManager.getLogger(BasicDecider.class);
 

--- a/pipedev-workflow-utils/pom.xml
+++ b/pipedev-workflow-utils/pom.xml
@@ -21,6 +21,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <version>1.8</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.github.seqware</groupId>
             <artifactId>seqware-pipeline</artifactId>
         </dependency>

--- a/pipedev-workflow-utils/src/main/java/ca/on/oicr/pde/utilities/workflows/OicrModule.java
+++ b/pipedev-workflow-utils/src/main/java/ca/on/oicr/pde/utilities/workflows/OicrModule.java
@@ -10,7 +10,7 @@ import joptsimple.OptionSet;
 import net.sourceforge.seqware.common.module.ReturnValue;
 import net.sourceforge.seqware.pipeline.module.Module;
 import net.sourceforge.seqware.pipeline.module.ModuleInterface;
-import org.openide.util.lookup.ServiceProvider;
+import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Morgan Taschuk, Brian O'Connor
  */
-@ServiceProvider(service = ModuleInterface.class)
+@MetaInfServices(ModuleInterface.class)
 public class OicrModule extends Module {
     private final Logger logger = LoggerFactory.getLogger(OicrModule.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ca.on.oicr.gsi</groupId>
     <artifactId>pipedev</artifactId>
-    <version>2.5.18</version>
+    <version>2.5.19</version>
     <packaging>pom</packaging>
     <url>http://maven.apache.org</url>
 
@@ -49,7 +49,7 @@
         
         <provenance-version>1.2.3</provenance-version>
         <seqware-version>2.0.6</seqware-version>
-        <pinery-version>2.15.0</pinery-version>
+        <pinery-version>2.19.0</pinery-version>
     </properties>
     
     <prerequisites>
@@ -66,7 +66,13 @@
     
     <dependencyManagement>
         <dependencies>
-                       
+            <dependency>
+                <groupId>org.kohsuke.metainf-services</groupId>
+                <artifactId>metainf-services</artifactId>
+                <version>1.8</version>
+                <optional>true</optional>
+            </dependency>
+                    
             <!-- seqware -->
             <dependency>
                 <groupId>com.github.seqware</groupId>


### PR DESCRIPTION
The `ServiceProvider` method for generating the `META-INF/services` does not
work on newer JDKs. There is a fix, but that would require releasing a new
version of Niassa, so this replaced it with the service generator used in
Shesmu which is fine on newer JDKs.